### PR TITLE
Updated dependency versions to latest available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vulkano_text"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2018"
 authors = ["Rukai <rubickent@gmail.com>"]
 description = "Render text with the DejaVu font using the Vulkano library."
@@ -9,10 +9,10 @@ repository = "https://github.com/rukai/vulkano-text"
 keywords = ["vulkano", "text", "font"]
 
 [dependencies]
-rusttype = { version = "0.7", features = ["gpu_cache"] }
-vulkano = "0.13"
-vulkano-shaders = "0.13"
+rusttype = { version = "0.8", features = ["gpu_cache"] }
+vulkano = "0.17"
+vulkano-shaders = "0.17"
 
 [dev-dependencies]
-winit = "0.19"
-vulkano-win = "0.13"
+winit = "0.21"
+vulkano-win = "0.17"

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -1,23 +1,53 @@
 use vulkano_text::{DrawText, DrawTextTrait};
 
-use vulkano::command_buffer::AutoCommandBufferBuilder;
+use vulkano::command_buffer::{AutoCommandBufferBuilder, DynamicState};
 use vulkano::device::{Device, DeviceExtensions};
 use vulkano::format::Format;
-use vulkano::framebuffer::Framebuffer;
+use vulkano::framebuffer::{Framebuffer, FramebufferAbstract, RenderPassAbstract};
 use vulkano::image::attachment::AttachmentImage;
+use vulkano::image::SwapchainImage;
 use vulkano::instance::{Instance, PhysicalDevice};
-use vulkano::swapchain::{AcquireError, PresentMode, SurfaceTransform, Swapchain, SwapchainCreationError};
+use vulkano::pipeline::viewport::Viewport;
+use vulkano::swapchain::{AcquireError, PresentMode, SurfaceTransform, Swapchain, SwapchainCreationError, ColorSpace, FullscreenExclusive};
 use vulkano::swapchain;
 use vulkano::sync::{GpuFuture, FlushError};
 use vulkano::sync;
 
 use vulkano_win::VkSurfaceBuild;
 
-use winit::{EventsLoop, WindowBuilder, Event, WindowEvent};
+use winit::window::{WindowBuilder, Window};
+use winit::event_loop::{EventLoop, ControlFlow};
+use winit::event::{Event, WindowEvent};
 
 use std::sync::Arc;
 use std::time::Instant;
 use std::env;
+
+fn window_size_dependent_setup(
+    device: Arc<Device>,
+    images: &[Arc<SwapchainImage<Window>>],
+    render_pass: Arc<dyn RenderPassAbstract + Send + Sync>,
+    dynamic_state: &mut DynamicState
+) -> Vec<Arc<dyn FramebufferAbstract + Send + Sync>> {
+    let dimensions = images[0].dimensions();
+
+    let viewport = Viewport {
+        origin: [0.0, 0.0],
+        dimensions: [dimensions[0] as f32, dimensions[1] as f32],
+        depth_range: 0.0 .. 1.0,
+    };
+    dynamic_state.viewports = Some(vec!(viewport));
+
+    let depthbuffer = AttachmentImage::transient(device.clone(), images[0].dimensions(), Format::D16Unorm).unwrap();
+    images.iter().map(|image| {
+        Arc::new(
+            Framebuffer::start(render_pass.clone())
+                .add(image.clone()).unwrap()
+                .add(depthbuffer.clone()).unwrap()
+                .build().unwrap()
+        ) as Arc<dyn FramebufferAbstract + Send + Sync>
+    }).collect::<Vec<_>>()
+}
 
 fn main() {
     let lines = vec!(
@@ -99,40 +129,30 @@ fn main() {
         None      => None,
     };
 
-    let extensions = vulkano_win::required_extensions();
-    let instance = Instance::new(None, &extensions, None).unwrap();
-
+    let required_extensions = vulkano_win::required_extensions();
+    let instance = Instance::new(None, &required_extensions, None).unwrap();
     let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
     println!("Using device: {} (type: {:?})", physical.name(), physical.ty());
 
-    let mut events_loop = EventsLoop::new();
-    let surface = WindowBuilder::new().build_vk_surface(&events_loop, instance.clone()).unwrap();
-    let window = surface.window();
-
+    let event_loop = EventLoop::new();
+    let surface = WindowBuilder::new().build_vk_surface(&event_loop, instance.clone()).unwrap();
     let queue_family = physical.queue_families().find(|&q| {
         q.supports_graphics() && surface.is_supported(q).unwrap_or(false)
     }).unwrap();
-
     let device_ext = DeviceExtensions { khr_swapchain: true, .. DeviceExtensions::none() };
     let (device, mut queues) = Device::new(physical, physical.supported_features(), &device_ext,
         [(queue_family, 0.5)].iter().cloned()).unwrap();
     let queue = queues.next().unwrap();
-
-    let initial_dimensions = if let Some(dimensions) = window.get_inner_size() {
-        let dimensions: (u32, u32) = dimensions.to_physical(window.get_hidpi_factor()).into();
-        [dimensions.0, dimensions.1]
-    } else {
-        return;
-    };
-
     let (mut swapchain, images) = {
         let caps = surface.capabilities(physical).unwrap();
         let usage = caps.supported_usage_flags;
         let alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
+        let dimensions: [u32; 2] = surface.window().inner_size().into();
+        Swapchain::new(device.clone(), surface.clone(), caps.min_image_count, format,
+            dimensions, 1, usage, &queue, SurfaceTransform::Identity, alpha,
+            PresentMode::Fifo, FullscreenExclusive::Default, true, ColorSpace::SrgbNonLinear).unwrap()
 
-        Swapchain::new(device.clone(), surface.clone(), caps.min_image_count, format, initial_dimensions,
-            1, usage, &queue, SurfaceTransform::Identity, alpha, PresentMode::Fifo, true, None).unwrap()
     };
 
     // include a depth buffer (unlike triangle.rs) to ensure vulkano-text isnt dependent on a specific render_pass
@@ -158,118 +178,107 @@ fn main() {
         }
     ).unwrap());
 
-    let depthbuffer = AttachmentImage::transient(device.clone(), images[0].dimensions(), Format::D16Unorm).unwrap();
-    let mut framebuffers = images.iter().map(|image| {
-        Arc::new(Framebuffer::start(render_pass.clone())
-            .add(image.clone()).unwrap()
-            .add(depthbuffer.clone()).unwrap()
-            .build().unwrap())
-    }).collect::<Vec<_>>();
-
     let mut draw_text = DrawText::new(device.clone(), queue.clone(), swapchain.clone(), &images);
 
-    let (width, _): (u32, u32) = surface.window().get_inner_size().unwrap().into();
+    let (width, _): (u32, u32) = surface.window().inner_size().into();
     let mut x = 0.0;
 
+    let mut dynamic_state = DynamicState { line_width: None, viewports: None, scissors: None, compare_mask: None, write_mask: None, reference: None };
+    let mut framebuffers = window_size_dependent_setup(device.clone(), &images, render_pass.clone(), &mut dynamic_state);
     let mut recreate_swapchain = false;
-    let mut previous_frame_end = Box::new(sync::now(device.clone())) as Box<dyn GpuFuture>;
+    let mut previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<dyn GpuFuture>);
 
     let start = Instant::now();
     let mut frames_rendered = 0;
-    loop {
-        frames_rendered += 1;
-        previous_frame_end.cleanup_finished();
-        if recreate_swapchain {
-            let dimensions = if let Some(dimensions) = window.get_inner_size() {
-                let dimensions: (u32, u32) = dimensions.to_physical(window.get_hidpi_factor()).into();
-                [dimensions.0, dimensions.1]
-            } else {
-                return;
-            };
-
-            let (new_swapchain, new_images) = match swapchain.recreate_with_dimension(dimensions) {
-                Ok(r) => r,
-                Err(SwapchainCreationError::UnsupportedDimensions) => continue,
-                Err(err) => panic!("{:?}", err)
-            };
-
-            swapchain = new_swapchain;
-            let depthbuffer = AttachmentImage::transient(device.clone(), new_images[0].dimensions(), Format::D16Unorm).unwrap();
-            framebuffers = new_images.iter().map(|image| {
-                Arc::new(Framebuffer::start(render_pass.clone())
-                    .add(image.clone()).unwrap()
-                    .add(depthbuffer.clone()).unwrap()
-                    .build().unwrap())
-            }).collect::<Vec<_>>();
-
-            draw_text = DrawText::new(device.clone(), queue.clone(), swapchain.clone(), &new_images);
-
-            recreate_swapchain = false;
-        }
-
-        if x > width as f32 {
-            x = 0.0;
-        }
-        else {
-            x += 2.0;
-        }
-
-        for (i, line) in lines.iter().enumerate() {
-            draw_text.queue_text(x, (i + 1) as f32 * 15.0, 15.0, [1.0, 1.0, 1.0, 1.0], line);
-        }
-
-        let (image_num, acquire_future) = match swapchain::acquire_next_image(swapchain.clone(), None) {
-            Ok(r) => r,
-            Err(AcquireError::OutOfDate) => {
-                recreate_swapchain = true;
-                continue;
+    event_loop.run(move |event, _, control_flow| {
+        match event {
+            Event::WindowEvent { event: WindowEvent::CloseRequested, .. } => {
+                *control_flow = ControlFlow::Exit;
             },
-            Err(err) => panic!("{:?}", err)
-        };
-
-        let clear_values = vec!([0.0, 0.0, 0.0, 1.0].into(), 1f32.into());
-        let command_buffer = AutoCommandBufferBuilder::primary_one_time_submit(device.clone(), queue.family()).unwrap()
-            .begin_render_pass(framebuffers[image_num].clone(), false, clear_values).unwrap()
-            .end_render_pass().unwrap()
-            .draw_text(&mut draw_text, image_num)
-            .build().unwrap();
-
-        let future = previous_frame_end.join(acquire_future)
-            .then_execute(queue.clone(), command_buffer).unwrap()
-            .then_swapchain_present(queue.clone(), swapchain.clone(), image_num)
-            .then_signal_fence_and_flush();
-
-        match future {
-            Ok(future) => {
-                previous_frame_end = Box::new(future) as Box<_>;
-            }
-            Err(FlushError::OutOfDate) => {
+            Event::WindowEvent { event: WindowEvent::Resized(_), .. } => {
                 recreate_swapchain = true;
-                previous_frame_end = Box::new(sync::now(device.clone())) as Box<_>;
-            }
-            Err(e) => {
-                println!("{:?}", e);
-                previous_frame_end = Box::new(sync::now(device.clone())) as Box<_>;
-            }
-        }
+            },
+            Event::RedrawEventsCleared => {
+                previous_frame_end.as_mut().unwrap().cleanup_finished();
+                if recreate_swapchain {
+                    let dimensions: [u32; 2] = surface.window().inner_size().into();
+                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimensions(dimensions) {
+                        Ok(r) => r,
+                        Err(SwapchainCreationError::UnsupportedDimensions) => return,
+                        Err(e) => panic!("Failed to recreate swapchain: {:?}", e)
+                    };
 
-        let mut done = false;
-        events_loop.poll_events(|ev| {
-            match ev {
-                Event::WindowEvent { event: WindowEvent::CloseRequested, .. } => done = true,
-                Event::WindowEvent { event: WindowEvent::Resized(_), .. } => recreate_swapchain = true,
-                _ => ()
-            }
-        });
-        if done { break; }
-        if let Some(max_frames) = benchmark_count {
-            if frames_rendered >= max_frames {
-                break;
-            }
-        }
-    }
-    let duration = start.elapsed();
+                    swapchain = new_swapchain;
+                    framebuffers = window_size_dependent_setup(device.clone(), &new_images, render_pass.clone(), &mut dynamic_state);
 
-    println!("Total Duration: {:?}", duration);
-    println!("Average render Duration: {:?}", duration / frames_rendered as u32);
+                    draw_text = DrawText::new(device.clone(), queue.clone(), swapchain.clone(), &new_images);
+
+                    recreate_swapchain = false;
+                }
+
+                if x > width as f32 {
+                    x = 0.0;
+                }
+                else {
+                    x += 2.0;
+                }
+                
+                for (i, line) in lines.iter().enumerate() {
+                    draw_text.queue_text(x, (i + 1) as f32 * 15.0, 15.0, [1.0, 1.0, 1.0, 1.0], line);
+                }
+                
+                let (image_num, suboptimal, acquire_future) = match swapchain::acquire_next_image(swapchain.clone(), None) {
+                    Ok(r) => r,
+                    Err(AcquireError::OutOfDate) => {
+                        recreate_swapchain = true;
+                        return;
+                    },
+                    Err(e) => panic!("Failed to acquire next image: {:?}", e)
+                };
+
+                if suboptimal {
+                    recreate_swapchain = true;
+                }
+
+                let clear_values = vec!([0.0, 0.0, 0.0, 1.0].into(), 1f32.into());
+                let command_buffer = AutoCommandBufferBuilder::primary_one_time_submit(device.clone(), queue.family()).unwrap()
+                    .begin_render_pass(framebuffers[image_num].clone(), false, clear_values).unwrap()
+                    .end_render_pass().unwrap()
+                    .draw_text(&mut draw_text, image_num)
+                    .build().unwrap();
+
+                let future = previous_frame_end.take().unwrap()
+                    .join(acquire_future)
+                    .then_execute(queue.clone(), command_buffer).unwrap()
+                    .then_swapchain_present(queue.clone(), swapchain.clone(), image_num)
+                    .then_signal_fence_and_flush();
+
+                match future {
+                    Ok(future) => {
+                        previous_frame_end = Some(Box::new(future) as Box<_>);
+                    },
+                    Err(FlushError::OutOfDate) => {
+                        recreate_swapchain = true;
+                        previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                    }
+                    Err(e) => {
+                        println!("Failed to flush future: {:?}", e);
+                        previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                    }
+                }
+
+                frames_rendered += 1;
+                if let Some(max_frames) = benchmark_count {
+                    if frames_rendered >= max_frames {
+                        let duration = start.elapsed();
+                        println!("Total Duration: {:?}", duration);
+                        println!("Average render Duration: {:?}", duration / frames_rendered as u32);
+                        *control_flow = ControlFlow::Exit;
+                    }
+                }
+            },
+            _ => ()
+        }
+    });
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,7 @@ impl DrawText {
         let buffer = CpuAccessibleBuffer::<[u8]>::from_iter(
             self.device.clone(),
             BufferUsage::all(),
+            false,
             cache_pixel_buffer.iter().cloned()
         ).unwrap();
 
@@ -192,7 +193,7 @@ impl DrawText {
         ).unwrap();
 
         let set = Arc::new(
-            PersistentDescriptorSet::start(self.pipeline.clone(), 0)
+            PersistentDescriptorSet::start(self.pipeline.descriptor_set_layout(0).unwrap().clone())
             .add_sampled_image(cache_texture.clone(), sampler).unwrap()
             .build().unwrap()
         );
@@ -257,7 +258,7 @@ impl DrawText {
                 }
             }).collect();
 
-            let vertex_buffer = CpuAccessibleBuffer::from_iter(self.device.clone(), BufferUsage::all(), vertices.into_iter()).unwrap();
+            let vertex_buffer = CpuAccessibleBuffer::from_iter(self.device.clone(), BufferUsage::all(), false, vertices.into_iter()).unwrap();
             command_buffer = command_buffer.draw(self.pipeline.clone(), &DynamicState::none(), vertex_buffer.clone(), set.clone(), ()).unwrap();
         }
 


### PR DESCRIPTION
rusttype = 0.8
vulkano = 0.17
vulkano-shaders = 0.17

Updated `lib.rs` to match the modified Vulkano API. Removed and/or refactored code that referenced deprecated/refactored Vulkano API.
Updated examples to function with the Vulkano API changes.
Incremented version number in `Cargo.toml` to 0.12 from 0.11