### PR TITLE
Update to vulkano 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vulkano_text"
-version = "0.13.0"
+version = "0.12.0"
 edition = "2018"
 authors = ["Rukai <rubickent@gmail.com>"]
 description = "Render text with the DejaVu font using the Vulkano library."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ keywords = ["vulkano", "text", "font"]
 
 [dependencies]
 rusttype = { version = "0.8", features = ["gpu_cache"] }
-vulkano = "0.20.0"
-vulkano-shaders = "0.20.0"
+vulkano = "0.20"
+vulkano-shaders = "0.20"
 
 [dev-dependencies]
-winit = "0.24.0"
-vulkano-win = "0.20.0"
+winit = "0.24"
+vulkano-win = "0.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vulkano_text"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2018"
 authors = ["Rukai <rubickent@gmail.com>"]
 description = "Render text with the DejaVu font using the Vulkano library."
@@ -10,9 +10,9 @@ keywords = ["vulkano", "text", "font"]
 
 [dependencies]
 rusttype = { version = "0.8", features = ["gpu_cache"] }
-vulkano = "0.17"
-vulkano-shaders = "0.17"
+vulkano = "0.20.0"
+vulkano-shaders = "0.20.0"
 
 [dev-dependencies]
-winit = "0.21"
-vulkano-win = "0.17"
+winit = "0.24.0"
+vulkano-win = "0.20.0"

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -1,6 +1,6 @@
 use vulkano_text::{DrawText, DrawTextTrait};
 
-use vulkano::command_buffer::{AutoCommandBufferBuilder, DynamicState};
+use vulkano::command_buffer::{AutoCommandBufferBuilder, DynamicState, SubpassContents};
 use vulkano::device::{Device, DeviceExtensions};
 use vulkano::format::Format;
 use vulkano::framebuffer::{Framebuffer, FramebufferAbstract, RenderPassAbstract};
@@ -241,11 +241,14 @@ fn main() {
                 }
 
                 let clear_values = vec!([0.0, 0.0, 0.0, 1.0].into(), 1f32.into());
-                let command_buffer = AutoCommandBufferBuilder::primary_one_time_submit(device.clone(), queue.family()).unwrap()
-                    .begin_render_pass(framebuffers[image_num].clone(), false, clear_values).unwrap()
+                let mut builder = AutoCommandBufferBuilder::primary_one_time_submit(device.clone(), queue.family()).unwrap();
+
+                builder
+                    .begin_render_pass(framebuffers[image_num].clone(), SubpassContents::Inline, clear_values).unwrap()
                     .end_render_pass().unwrap()
-                    .draw_text(&mut draw_text, image_num)
-                    .build().unwrap();
+                    .draw_text(&mut draw_text, image_num);
+
+                let command_buffer = builder.build().unwrap();
 
                 let future = previous_frame_end.take().unwrap()
                     .join(acquire_future)

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -6,7 +6,7 @@ use vulkano_text::{DrawText, DrawTextTrait};
 // IMPORT END
 
 use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
-use vulkano::command_buffer::{AutoCommandBufferBuilder, DynamicState};
+use vulkano::command_buffer::{AutoCommandBufferBuilder, DynamicState, SubpassContents};
 use vulkano::device::{Device, DeviceExtensions};
 use vulkano::framebuffer::{Framebuffer, FramebufferAbstract, Subpass, RenderPassAbstract};
 use vulkano::image::SwapchainImage;
@@ -192,14 +192,17 @@ fn main() {
 
                 let clear_values = vec!([0.0, 0.0, 0.0, 1.0].into()); // CHANGED TO BLACK BACKGROUND
 
-                let command_buffer = AutoCommandBufferBuilder::primary_one_time_submit(device.clone(), queue.family()).unwrap()
-                    .begin_render_pass(framebuffers[image_num].clone(), false, clear_values).unwrap()
+                let mut builder = AutoCommandBufferBuilder::primary_one_time_submit(device.clone(), queue.family()).unwrap();
+
+                builder
+                    .begin_render_pass(framebuffers[image_num].clone(), SubpassContents::Inline, clear_values).unwrap()
                     .draw(pipeline.clone(), &dynamic_state, vertex_buffer.clone(), (), ()).unwrap()
                     .end_render_pass().unwrap()
                     // DRAW THE TEXT
-                    .draw_text(&mut draw_text, image_num)
+                    .draw_text(&mut draw_text, image_num);
                     // DRAW THE TEXT END
-                    .build().unwrap();
+                
+                let command_buffer = builder.build().unwrap();
 
                 let future = previous_frame_end.take().unwrap()
                     .join(acquire_future)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use rusttype::{Font, PositionedGlyph, Scale, Rect, point};
 use rusttype::gpu_cache::Cache;
 
 use vulkano::buffer::{CpuAccessibleBuffer, BufferUsage};
-use vulkano::command_buffer::{DynamicState, AutoCommandBufferBuilder};
+use vulkano::command_buffer::{DynamicState, AutoCommandBufferBuilder, SubpassContents};
 use vulkano::descriptor::descriptor_set::{PersistentDescriptorSet};
 use vulkano::descriptor::pipeline_layout::PipelineLayoutAbstract;
 use vulkano::device::{Device, Queue};
@@ -135,7 +135,7 @@ impl DrawText {
         });
     }
 
-    pub fn draw_text(&mut self, command_buffer: AutoCommandBufferBuilder, image_num: usize) -> AutoCommandBufferBuilder {
+    pub fn draw_text<'a>(&mut self, command_buffer: &'a mut AutoCommandBufferBuilder, image_num: usize) -> &'a mut AutoCommandBufferBuilder {
         let screen_width  = self.framebuffers[image_num].dimensions()[0];
         let screen_height = self.framebuffers[image_num].dimensions()[1];
         let cache_pixel_buffer = &mut self.cache_pixel_buffer;
@@ -203,7 +203,7 @@ impl DrawText {
                 buffer.clone(),
                 cache_texture_write,
             ).unwrap()
-            .begin_render_pass(self.framebuffers[image_num].clone(), false, vec!(ClearValue::None)).unwrap();
+            .begin_render_pass(self.framebuffers[image_num].clone(), SubpassContents::Inline, vec!(ClearValue::None)).unwrap();
 
         // draw
         for text in &mut self.texts.drain(..) {
@@ -267,11 +267,11 @@ impl DrawText {
 }
 
 impl DrawTextTrait for AutoCommandBufferBuilder {
-    fn draw_text(self, data: &mut DrawText, image_num: usize) -> AutoCommandBufferBuilder {
+    fn draw_text(&mut self, data: &mut DrawText, image_num: usize) -> &mut Self {
         data.draw_text(self, image_num)
     }
 }
 
 pub trait DrawTextTrait {
-    fn draw_text(self, data: &mut DrawText, image_num: usize) -> AutoCommandBufferBuilder;
+    fn draw_text(&mut self, data: &mut DrawText, image_num: usize) -> &mut Self;
 }


### PR DESCRIPTION
Hey! I wanted to use this repository with `vulkano = "0.20.0"` so I updated the vulkano dependencies:
- `vulkano = "0.17"` -> `vulkano = "0.20"`
- `vulkano-shaders = "0.17"` -> `vulkano-shaders = "0.20"`
- `vulkano-win = "0.17"` -> `vulkano = "0.20"`
- `winit= "0.21"` -> `vulkano = "0.24"`

For completeness I also tried updating `rusttype`, but ran into a lifetime issue related to the removal of [`PositionedGlyph::standalone`](https://docs.rs/rusttype/0.8.3/rusttype/struct.PositionedGlyph.html#method.standalone).